### PR TITLE
Change app name and change notice

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,4 @@
 K-9 Mail
 Copyright 2008-2016, K-9 Mail Developers
 Copyright 2005-2016, The Android Open Source Project
+Copyright 2017, K-9 Material Developers

--- a/k9mail/src/main/res/values-bg/strings.xml
+++ b/k9mail/src/main/res/values-bg/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9 Material</string>
   <string name="shortcuts_title">K-9 Профили</string>
   <string name="unread_widget_label">K-9 Непрочетени</string>
   <string name="remote_control_label">K-9 Mail дистанционно управление</string>

--- a/k9mail/src/main/res/values-ca/strings.xml
+++ b/k9mail/src/main/res/values-ca/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9 Material</string>
   <string name="shortcuts_title">Comptes K-9</string>
   <string name="unread_widget_label">K-9 no llegits</string>
   <string name="remote_control_label">Control remot del Correu K-9 Mail</string>

--- a/k9mail/src/main/res/values-cs/strings.xml
+++ b/k9mail/src/main/res/values-cs/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9 Material</string>
   <string name="shortcuts_title">Účty K-9</string>
   <string name="unread_widget_label">K-9 Nepřečtená</string>
   <string name="remote_control_label">Dálkové ovládání pošty K-9 Mail</string>

--- a/k9mail/src/main/res/values-da/strings.xml
+++ b/k9mail/src/main/res/values-da/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9 Material</string>
   <string name="shortcuts_title">K-9 Konti</string>
   <string name="unread_widget_label">K-9 Ulæst</string>
   <string name="remote_control_label">K-9 Mail fjernkontrol</string>

--- a/k9mail/src/main/res/values-el/strings.xml
+++ b/k9mail/src/main/res/values-el/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Λογαριασμοί K-9</string>
   <string name="unread_widget_label">Μη αναγνωσμένα K-9</string>
   <string name="remote_control_label">Τηλεχειριστήριο K-9 Mail</string>

--- a/k9mail/src/main/res/values-es/strings.xml
+++ b/k9mail/src/main/res/values-es/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Cuentas K-9</string>
   <string name="unread_widget_label">Mensaje K-9 no leído</string>
   <string name="remote_control_label">Control remoto K-9 Mail</string>

--- a/k9mail/src/main/res/values-et/strings.xml
+++ b/k9mail/src/main/res/values-et/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Kontod</string>
   <string name="unread_widget_label">K-9 Lugemata</string>
   <string name="remote_control_label">K-9 Mail kaughaldus</string>

--- a/k9mail/src/main/res/values-eu/strings.xml
+++ b/k9mail/src/main/res/values-eu/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 kontuak</string>
   <string name="unread_widget_label">K-9 irakurgabeak</string>
   <string name="remote_control_label">K-9 urruneko kontrola</string>

--- a/k9mail/src/main/res/values-fa/strings.xml
+++ b/k9mail/src/main/res/values-fa/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">حساب کاربری ک-9</string>
   <string name="unread_widget_label">ک-9 خوانده نشده</string>
   <string name="remote_control_label">کنترل از راه دور نامه ک-9</string>

--- a/k9mail/src/main/res/values-fi/strings.xml
+++ b/k9mail/src/main/res/values-fi/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9-tilit</string>
   <string name="unread_widget_label">K-9-lukematon</string>
   <string name="remote_control_label">K-9 Mailin etäkäyttö</string>

--- a/k9mail/src/main/res/values-fr/strings.xml
+++ b/k9mail/src/main/res/values-fr/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Comptes K-9</string>
   <string name="unread_widget_label">K-9 non lus</string>
   <string name="remote_control_label">Contrôle à distance de Courriel K-9 Mail</string>

--- a/k9mail/src/main/res/values-gl-rES/strings.xml
+++ b/k9mail/src/main/res/values-gl-rES/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Contas K-9</string>
   <string name="unread_widget_label">K-9 non lidas</string>
   <string name="remote_control_label">Control remoto de K-9 Mail</string>

--- a/k9mail/src/main/res/values-gl/strings.xml
+++ b/k9mail/src/main/res/values-gl/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Contas K-9</string>
   <string name="remote_control_label">Control remoto K-9 Mail</string>
   <string name="remote_control_desc">Permite a esta aplicación controlar as actividades e Configuración de K-9 Mail</string>

--- a/k9mail/src/main/res/values-hr/strings.xml
+++ b/k9mail/src/main/res/values-hr/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Računi</string>
   <string name="unread_widget_label">K-9 Nepročitano</string>
   <string name="remote_control_label">K-9 Mail daljinski upravljač</string>

--- a/k9mail/src/main/res/values-hu/strings.xml
+++ b/k9mail/src/main/res/values-hu/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 fiókok</string>
   <string name="unread_widget_label">K-9 olvasatlan</string>
   <string name="remote_control_label">K-9 Mail távoli vezérlés</string>

--- a/k9mail/src/main/res/values-it/strings.xml
+++ b/k9mail/src/main/res/values-it/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Account di K-9</string>
   <string name="unread_widget_label">Nuovi messaggi di K-9</string>
   <string name="remote_control_label">Controllo remoto di K-9 Mail</string>

--- a/k9mail/src/main/res/values-ja/strings.xml
+++ b/k9mail/src/main/res/values-ja/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 アカウント</string>
   <string name="unread_widget_label">未読件数</string>
   <string name="remote_control_label">K-9 Mail リモート制御</string>

--- a/k9mail/src/main/res/values-ko/strings.xml
+++ b/k9mail/src/main/res/values-ko/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 계정</string>
   <string name="unread_widget_label">K-9 읽지 않은 메일</string>
   <string name="remote_control_label">K-9 메일 리모콘</string>

--- a/k9mail/src/main/res/values-lt/strings.xml
+++ b/k9mail/src/main/res/values-lt/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 paskyros</string>
   <string name="unread_widget_label">K-9 neskaityta</string>
   <string name="remote_control_label">„K-9 Mail“ nutolęs valdymas</string>

--- a/k9mail/src/main/res/values-lv/strings.xml
+++ b/k9mail/src/main/res/values-lv/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Konti</string>
   <string name="unread_widget_label">K-9 Nelasīts</string>
   <string name="remote_control_label">K-9 Pasta attālinātā vadīšana</string>

--- a/k9mail/src/main/res/values-nb/strings.xml
+++ b/k9mail/src/main/res/values-nb/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Konti</string>
   <string name="unread_widget_label">K-9 Ulest</string>
   <string name="remote_control_label">K-9 E-post fjernkontroll</string>

--- a/k9mail/src/main/res/values-nl/strings.xml
+++ b/k9mail/src/main/res/values-nl/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Accounts</string>
   <string name="unread_widget_label">K-9 Ongelezen</string>
   <string name="remote_control_label">K-9 Mail bediening op afstand</string>

--- a/k9mail/src/main/res/values-pl/strings.xml
+++ b/k9mail/src/main/res/values-pl/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Konta K-9</string>
   <string name="unread_widget_label">K-9 Mail nieprzeczytane</string>
   <string name="remote_control_label">K-9 Mail zdalne sterowanie</string>

--- a/k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Contas K-9</string>
   <string name="unread_widget_label">K-9 Não lidos</string>
   <string name="remote_control_label">Controle remoto para K-9 Mail</string>

--- a/k9mail/src/main/res/values-pt-rPT/strings.xml
+++ b/k9mail/src/main/res/values-pt-rPT/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Contas K-9</string>
   <string name="unread_widget_label">K-9 Não lido</string>
   <string name="remote_control_label">Controlo remoto do K-9 Mail</string>

--- a/k9mail/src/main/res/values-ro/strings.xml
+++ b/k9mail/src/main/res/values-ro/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Conturi K-9</string>
   <string name="unread_widget_label">K-9 Necitite</string>
   <string name="remote_control_label">K-9 Mail remote control</string>

--- a/k9mail/src/main/res/values-ru/strings.xml
+++ b/k9mail/src/main/res/values-ru/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">Почтовые ящики K-9</string>
   <string name="unread_widget_label">Не прочитано</string>
   <string name="remote_control_label">Удалённое управление</string>

--- a/k9mail/src/main/res/values-sk/strings.xml
+++ b/k9mail/src/main/res/values-sk/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Účty</string>
   <string name="unread_widget_label">K-9 Neprečítaná</string>
   <string name="remote_control_label">diaľkové ovládanie K-9 Mail</string>

--- a/k9mail/src/main/res/values-sl/strings.xml
+++ b/k9mail/src/main/res/values-sl/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 računi</string>
   <string name="unread_widget_label">K-9 neprebrana</string>
   <string name="remote_control_label">K-9 Mail daljinsko upravljanje</string>

--- a/k9mail/src/main/res/values-sr/strings.xml
+++ b/k9mail/src/main/res/values-sr/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">К-9 налози</string>
   <string name="unread_widget_label">К-9 непрочитане</string>
   <string name="remote_control_label">К-9 даљинско управљање</string>

--- a/k9mail/src/main/res/values-sv/strings.xml
+++ b/k9mail/src/main/res/values-sv/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Konton</string>
   <string name="unread_widget_label">K-9 Olästa</string>
   <string name="remote_control_label">K-9 Mail fjärrkontroll</string>

--- a/k9mail/src/main/res/values-tr/strings.xml
+++ b/k9mail/src/main/res/values-tr/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Hesaplar</string>
   <string name="unread_widget_label">K-9 Okunmamış</string>
   <string name="remote_control_label">K-9 Posta\'ya uzaktan erişim</string>

--- a/k9mail/src/main/res/values-uk/strings.xml
+++ b/k9mail/src/main/res/values-uk/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 Облікові записи</string>
   <string name="unread_widget_label">K-9 Непрочитані</string>
   <string name="remote_control_label">Дистанційне управління K-9 Mail</string>

--- a/k9mail/src/main/res/values-zh-rCN/strings.xml
+++ b/k9mail/src/main/res/values-zh-rCN/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9 账户</string>
   <string name="unread_widget_label">K-9 未读</string>
   <string name="remote_control_label">K-9 Mail 远程控制</string>

--- a/k9mail/src/main/res/values-zh-rTW/strings.xml
+++ b/k9mail/src/main/res/values-zh-rTW/strings.xml
@@ -3,7 +3,7 @@
   <!--=== App-specific strings =============================================================-->
   <!--This should make it easier for forks to change the branding-->
   <!--Used in AndroidManifest.xml-->
-  <string name="app_name">K9 material (unofficial)</string>
+  <string name="app_name">K9-Material</string>
   <string name="shortcuts_title">K-9帳戶</string>
   <string name="unread_widget_label">K-9 未讀</string>
   <string name="remote_control_label">遠端控制K-9 Mail</string>


### PR DESCRIPTION
The license does not require us to add "(unofficial)" or anything related to that and it makes the app name unnecessarily long in most launchers.