### PR TITLE
swap read/unread colors

### DIFF
--- a/k9mail/src/main/res/values/themes.xml
+++ b/k9mail/src/main/res/values/themes.xml
@@ -55,8 +55,8 @@
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
         <item name="messageListSelectedBackgroundColor">#802196f3</item>
-        <item name="messageListReadItemBackgroundColor">#ffffff</item>
-        <item name="messageListUnreadItemBackgroundColor">#eeeeee</item>
+        <item name="messageListReadItemBackgroundColor">#eeeeee</item>
+        <item name="messageListUnreadItemBackgroundColor">#ffffff</item>
         <item name="messageListThreadCountForegroundColor">#ffffff</item>
         <item name="messageListThreadCountBackground">#9e9e9e</item>
         <item name="messageListActiveItemBackgroundColor">#ff2196f3</item>


### PR DESCRIPTION
So, I fired Android Studio up and used my rusty Android skills to patch #27 myself.

This fixes #27 by solely swapping the unread/read status background colors.
